### PR TITLE
Gallery exists, but the folder or path value does not

### DIFF
--- a/fanscrape.py
+++ b/fanscrape.py
@@ -297,7 +297,9 @@ def get_gallery_path(gallery_id):
     gallery = stash.find_gallery(gallery_id)
     # log.debug(gallery)
     if gallery:
-        return gallery["folder"]["path"]
+        if gallery.get("folder",None):
+            if gallery["folder"].get("path",None):
+                return gallery["folder"]["path"]
 
     log.error(f'Path for gallery {gallery_id} could not be found')
     print('null')


### PR DESCRIPTION
When a gallery exists but doesn't have a folder or path value, FanScrape crashes out with `could not unmarshal json from script output: EOF` as shown in this error Traceback:
```
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape] Traceback (most recent call last):"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape]   File \"/root/.stash/scrapers/fanscrape/fanscrape/fanscrape.py\", line 594, in <module>"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape]     main()"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape]   File \"/root/.stash/scrapers/fanscrape/fanscrape/fanscrape.py\", line 628, in main"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape]     path = Path(get_gallery_path(scrape_id))"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape]   File \"/root/.stash/scrapers/fanscrape/fanscrape/fanscrape.py\", line 300, in get_gallery_path"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape]     return gallery[\"folder\"][\"path\"]"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape]            ~~~~~~~~~~~~~~~~~^^^^^^^^"
time="2024-08-02 22:02:30" level=error msg="[Scrape / FanScrape] TypeError: 'NoneType' object is not subscriptable"
time="2024-08-02 22:02:30" level=error msg="could not unmarshal json from script output: EOF"
time="2024-08-02 22:02:30" level=error msg="scrapeSingleGallery: input: scrapeSingleGallery scraper fanscrape: could not unmarshal json from script output: EOF"
```

This pull request checks for either of them being None before returning the path.
