### PR TITLE
Fix 2 issues with loading db file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Above tools download posts from OnlyFans/Fansly and save metadata to 'user_data.
 [datawhores/OF-Scraper](https://github.com/datawhores/OF-Scraper)
 
 > [!IMPORTANT]\
-> If you are using datawhores/OF-Scraper you will need to change your scraper config.
-> The options you need to change can be found below.
+> If you are using datawhores/OF-Scraper you have two choices.
+> Either you will need to change your scraper config or add a setting to the [config.json](#configuration) file.
+> The options you need to change for OF-scraper can be found below.
 
 ```JSON
 "dir_format": "{sitename}/{model_username}/{responsetype}/{value}/{mediatype}",
@@ -188,7 +189,8 @@ The values in the default config are as follows:
     "max_performer_images": 3,              # Maximum performer images to generate.
     "cache_time": 300,                      # Image expiration time (in seconds).
     "cache_dir": "cache",                   # Directory to store cached base64 encoded images.
-    "cache_file": "cache.json"              # File to store cache information in.
+    "cache_file": "cache.json",             # File to store cache information in.
+    "meta_base_path": None,                 # Base path to search for 'user_data.db' files.
 }
 ```
 

--- a/fanscrape.py
+++ b/fanscrape.py
@@ -522,9 +522,11 @@ def get_path_info(path):
     network = 'Fansly' if 'Fansly' in str(path) else 'OnlyFans'
     try:
         path_parts = [item.lower() for item in path.parts]
-        index = path_parts.index(network.lower())
-        if (path.parts[index + 1] == "sites"):
-            index = path_parts.index(network.lower(), index + 1)
+        """
+        If the network is in the path multiple times get the last one
+        """
+        indexes = [index for index, element in enumerate(path_parts) if element == network]
+        index = indexes[-1] if indexes else None
         if index + 1 < len(path.parts):
             return  path.parts[index + 1], network, Path(*path.parts[:index + 2])
         raise ValueError

--- a/fanscrape.py
+++ b/fanscrape.py
@@ -523,6 +523,8 @@ def get_path_info(path):
     try:
         path_parts = [item.lower() for item in path.parts]
         index = path_parts.index(network.lower())
+        if (path.parts[index + 1] == "sites"):
+            index = path_parts.index(network.lower(), index + 1)
         if index + 1 < len(path.parts):
             return  path.parts[index + 1], network, Path(*path.parts[:index + 2])
         raise ValueError

--- a/fanscrape.py
+++ b/fanscrape.py
@@ -45,7 +45,8 @@ default_config = {
     "max_performer_images": 3,  # Maximum performer images to generate.
     "cache_time": 300,  # Image expiration time (in seconds).
     "cache_dir": "cache",  # Directory to store cached base64 encoded images.
-    "cache_file": "cache.json"  # File to store cache information in.
+    "cache_file": "cache.json",  # File to store cache information in.
+    "meta_base_path": None,  # Base path to search for 'user_data.db' files.
 }
 
 # Read config file
@@ -68,6 +69,7 @@ MAX_TITLE_LENGTH = config['max_title_length']
 TAG_MESSAGES = config['tag_messages']
 TAG_MESSAGES_NAME = config['tag_messages_name']
 MAX_PERFORMER_IMAGES = config['max_performer_images']
+META_BASE_PATH = config['meta_base_path']
 CACHE_TIME = config['cache_time']
 CACHE_DIR = config['cache_dir']
 CACHE_FILE = config['cache_file']
@@ -203,7 +205,7 @@ def lookup_scene(file, db, media_dir, username, network):
         scrape["tags"] = [{"name": TAG_MESSAGES_NAME}]
 
     return scrape
-    
+
 
 # GALLERIES ########################################################################################
 def lookup_gallery(file, db, media_dir, username, network):
@@ -576,7 +578,7 @@ def sanitize_string(string):
         string = re.sub(r"<[^>]*>", "", string)
         return string
     return string
-            
+
 
 # MAIN #############################################################################################
 def main():
@@ -585,6 +587,7 @@ def main():
     """
     fragment = json.loads(sys.stdin.read())
     scrape_id = fragment["id"]
+    meta_path = None
 
     if sys.argv[1] == "queryScene":
         lookup = lookup_scene
@@ -598,7 +601,9 @@ def main():
         sys.exit()
 
     username, network, media_dir = get_path_info(path)
-    db = get_metadata_db(path, username, network)
+    if META_BASE_PATH:
+        meta_path = Path(META_BASE_PATH)
+    db = get_metadata_db(meta_path or path, username, network)
 
     media = lookup(path, db, media_dir, username, network)
     print(json.dumps(media))


### PR DESCRIPTION
Add the ability to override the path of the metadata base folder, in case there are oddities in the path, like the Network name in the path twice or the folder for the metadata being different from the media

cleaned up a couple of places with tabs or other whitespace where it wasn't obvious