### PR TITLE
Fix for none in text field

### DIFF
--- a/fanscrape.py
+++ b/fanscrape.py
@@ -475,6 +475,8 @@ def process_row(row, username, network, filename, scene_index=0, scene_count=0):
     """
     Process a database row and format post details.
     """
+    if row[1] is None:
+        row[1] = ""
     date = row[2]
     if validate_datetime(date):
         date = datetime.fromisoformat(date)


### PR DESCRIPTION
I was chatting with Sadarex over Discord DMs, and he was running into an issue where sometimes the script would crash out because there was no text value passed to the process_row (and thus format_title)
At first, we worked around it by just replacing the text field with "" if row[1] was None. But after further digging, the sanitize_api_type returned the wrong table for that media. So, test if that text column is None first and then use COALESCE() to get text from the first matching table for that post_id.