### PR TITLE
bump GitHub Action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,17 @@ jobs:
       - uses: actions/checkout@master
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.5
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: "zip"
           filename: "fanscrape.zip"
           exclusions: "*.git* .editorconfig"
       - name: Upload Release
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           artifacts: "fanscrape.zip"
           tag: ${{ steps.tag_version.outputs.new_tag }}


### PR DESCRIPTION
with GitHub [removing support](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) for Node16 and now using Node20, the GitHub actions were throwing a warning and all of three have been updated