### PR TITLE
switching the rglob to case-insensitive

### DIFF
--- a/fanscrape.py
+++ b/fanscrape.py
@@ -503,7 +503,7 @@ def get_metadata_db(search_path, username, network):
     search_path = Path(search_path).resolve()
 
     while search_path != search_path.parent:
-        db_files = list(search_path.rglob(f"{network}/**/{username}/**/user_data.db"))
+        db_files = list(search_path.rglob(f"{network}/**/{username}/**/user_data.db", case_sensitive=False))
         db_files = [db for db in db_files if db.is_file()]
         if db_files:
             return db_files[0]


### PR DESCRIPTION
because in get_path_info everything is converted to lowercase rglob also needs to be case-insensitive, because as llll saw https://discord.com/channels/1180581719804493934/1186361675771813888/1270047903141986354 his network was Onlyfans not OnlyFans so the script couldn't find the db file.