### PR TITLE
Markdown removal and adding better direct path [breaking change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Above tools download posts from OnlyFans/Fansly and save metadata to 'user_data.
 
 ## Installation
 
+***Breaking Change:***
+As of commit `76f80f4`, this code requires the Python module `markdown` installed where Stash runs (this could be inside your docker container). Likely a command such as:
+```shell
+pip install markdown
+```
+or
+```shell
+pip3.12 install markdown --break-system-packages
+```
+
 ### Managed
 
 - Go to Settings > Metadata Providers > Available Scrapers.
@@ -107,7 +117,7 @@ The date will contain the date on which the post was created.
 
 ### Code
 
-The code will contain the `post_id` of the post as stored in the database. This may be the same across multiple scenes if they originate from the same OnlyFans post.
+The code will contain the unique file id based on the value in either `<link>` or `<linked>` columns of the `medias` table.
 
 ### Studio
 
@@ -191,9 +201,14 @@ The values in the default config are as follows:
     "cache_dir": "cache",                   # Directory to store cached base64 encoded images.
     "cache_file": "cache.json",             # File to store cache information in.
     "meta_base_path": None,                 # Base path to search for 'user_data.db' files.
+    "direct_db": {
+        "override": False,
+        "db_format": "/path/to/the/{network}/{username}/Metadata/user_data.db", # Format of the database path.
+    },  # Allow overriding the database path.
 }
 ```
 
 ## Thanks
 
 Thank you to [WithoutPants](https://github.com/WithoutPants) for originally writing the script, and to [xantor](https://github.com/xantror) for maintaining the script as well as writing the README.
+Additionally [Jakan-Kink](https://github.com/Jakan-Kink), who has been making some significant updates since the beginning of August 2024.

--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ Above tools download posts from OnlyFans/Fansly and save metadata to 'user_data.
 
 ## Installation
 
-***Breaking Change:***
-As of commit `76f80f4`, this code requires the Python module `markdown` installed where Stash runs (this could be inside your docker container). Likely a command such as:
-```shell
-pip install markdown
-```
-or
-```shell
-pip3.12 install markdown --break-system-packages
-```
+> [!WARNING] 
+> ***Breaking Change:***
+> As of commit `76f80f4`, this code requires the Python module `markdown` installed where Stash runs (this could be inside your docker container). Likely a command such as:
+> ```shell
+> pip install markdown
+> ```
+> or
+> ```shell
+> pip3.12 install markdown --break-system-packages
+> ```
 
 ### Managed
 

--- a/fanscrape.py
+++ b/fanscrape.py
@@ -607,7 +607,7 @@ def parse_row_to_studio_code(row: tuple = ()) -> str:
         if row[3]:
             if row[3] == "www.onlyfans.com":
                 row = (row[0], row[1], row[2], None, row[4])
-        converted_url = urlparse(row[3])
+        converted_url = urlparse(row[3]) if row[3] else urlparse(row[4])
         converted_path = converted_url.path
         converted_array = converted_path.split("/")
         converted_filename = converted_array[-1]

--- a/fanscrape.py
+++ b/fanscrape.py
@@ -61,7 +61,18 @@ default_config = {
     "cache_dir": "cache",  # Directory to store cached base64 encoded images.
     "cache_file": "cache.json",  # File to store cache information in.
     "meta_base_path": None,  # Base path to search for 'user_data.db' files.
+    "direct_db": {
+        "override": False,
+        "db_format": None,
+    },  # Allow overriding the database path.
 }
+"""
+"direct_db": {
+    "override" : True, # Allow overriding the database path.
+    "db_format" : "/path/to/the/{network}/{username}/Metadata/user_data.db", # Format of the database path.
+}
+"""
+
 
 # Read config file
 try:
@@ -87,6 +98,7 @@ META_BASE_PATH = config["meta_base_path"]
 CACHE_TIME = config["cache_time"]
 CACHE_DIR = config["cache_dir"]
 CACHE_FILE = config["cache_file"]
+DIRECT_DB = config["direct_db"]
 
 
 def convert_datetime(val):
@@ -657,6 +669,21 @@ def get_metadata_db(search_path, username, network):
     """
     Recursively search for 'user_data.db' file starting from 'search_path'
     """
+    if "override" in DIRECT_DB and DIRECT_DB["override"]:
+        log.debug("Using direct database path override")
+        db_file = Path(
+            DIRECT_DB["db_format"].format(username=username, network=network)
+        )
+        log.debug(f"Path to db_file: {db_file}")
+        db_file = db_file.joinpath("user_data.db")
+
+        if db_file.is_file():
+            log.debug(f"Using direct database path: {db_file}")
+            return db_file
+        else:
+            log.error(f"The {db_file} path doesn't match a file.")
+    if META_BASE_PATH:
+        search_path = Path(META_BASE_PATH).resolve()
     search_path = Path(search_path).resolve()
 
     while search_path != search_path.parent:
@@ -806,8 +833,8 @@ def main():
     """
     fragment = json.loads(sys.stdin.read())
     scrape_id = fragment["id"]
-    meta_path = None
 
+    start_time = time.monotonic()
     if sys.argv[1] == "queryScene":
         lookup = lookup_scene
         if fragment.get("files", None) is not None:
@@ -822,10 +849,18 @@ def main():
         print("null")
         sys.exit()
 
+    log.debug(
+        f"Script runtime: after scene path: {time.monotonic() - start_time} seconds"
+    )
     username, network, media_dir = get_path_info(path)
-    if META_BASE_PATH:
-        meta_path = Path(META_BASE_PATH)
-    db = get_metadata_db(meta_path or path, username, network)
+    log.debug(
+        f"Script runtime: after scene path: {time.monotonic() - start_time} seconds"
+    )
+
+    db = get_metadata_db(path, username, network)
+    log.debug(
+        f"Script runtime: after metadata db: {time.monotonic() - start_time} seconds"
+    )
 
     if db is None:
         log.error("The db was not found, exiting.")
@@ -833,7 +868,12 @@ def main():
         sys.exit()
 
     media = lookup(path, db, media_dir, username, network)
+    log.debug(
+        f"Script runtime: after media lookup: {time.monotonic() - start_time} seconds"
+    )
     print(json.dumps(media))
+
+    log.debug(f"Script runtime: total runtime: {time.monotonic() - start_time} seconds")
     sys.exit()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 stashapp-tools
 sqlite3
+markdown


### PR DESCRIPTION
This PR merges three branches of my work:
direct-db-path
markdown-removal
more-data

*Markdown removal*
This branch was requested by robbyduran on Discord. This branch removes all of the markdown formatting in the title of a post. So a title that would have been `***Don't miss out on this ...etc***` is now just `Don't miss out on this etc`

*More Data*
This branch was added because if an api_type were not in the `sanitize_api_type` function, this script would exit. However, in PR #7, I added code to search all four possible tables, eliminating the need to exit.
A new column, `linked`, was also added to the schema, which in some cases was the same as `link` and in others replaced it. So, if the file unique ID wasn't in `link`, switch over to using `linked`.

*Direct DB Path*
worked on this code with @dat_nsfw_shit on Discord:
-This commit adds an override configuration to the config file so it can define the full path to the user_data.db file/files, this should also help if you are using the all-in-one db instead of the per user (but might need some more code tweaks)
-time logging and fix file naming

This code skips the search for the user_data.db file and goes direct, but it needs to have a correctly formatted string